### PR TITLE
Improve docs and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Xcode and Swift Package Manager
+DerivedData/
+.build/
+
+# General macOS files
+.DS_Store
+
+# Xcode project user data
+*.xcuserdatad/

--- a/HomeInventory/APIClient.swift
+++ b/HomeInventory/APIClient.swift
@@ -17,8 +17,16 @@ import SwiftUI
 
 class APIClient {
     static let shared = APIClient()
-    //private let baseURL = URL(string: "http://localhost:8000")!
-    private let baseURL = URL(string: "http://127.0.0.1:8000")!
+    /// Base URL for API requests. Can be overridden by the `API_BASE_URL`
+    /// environment variable to allow talking to different backends without
+    /// changing code.
+    private let baseURL: URL = {
+        if let urlString = ProcessInfo.processInfo.environment["API_BASE_URL"],
+           let url = URL(string: urlString) {
+            return url
+        }
+        return URL(string: "http://127.0.0.1:8000")!
+    }()
 
     private let session: URLSession
     var authToken: String? // set this before calling secured endpoints

--- a/HomeInventory/AddItemView.swift
+++ b/HomeInventory/AddItemView.swift
@@ -15,6 +15,7 @@ struct AddItemView: View {
     @State private var note = ""
     @State private var photo: Data?
     @State private var selectedPhoto: PhotosPickerItem?
+    @State private var errorMessage: String?
 
     var body: some View {
         NavigationStack {
@@ -39,6 +40,11 @@ struct AddItemView: View {
                 }
             }
             .navigationTitle("Add Item")
+            .alert("Error", isPresented: .constant(errorMessage != nil), actions: {
+                Button("OK", role: .cancel) { errorMessage = nil }
+            }, message: {
+                if let msg = errorMessage { Text(msg) }
+            })
         }
     }
 
@@ -56,8 +62,7 @@ struct AddItemView: View {
                     dismiss()
                 }
             } catch {
-                print("Error adding item: \(error)")
-                // Consider showing an error alert to the user
+                errorMessage = "Error adding item: \(error.localizedDescription)"
             }
         }
     }

--- a/HomeInventory/ContentView.swift
+++ b/HomeInventory/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     @State private var isShowingAddSheet = false
     @State private var searchText = ""
     @State private var searchResults: [Item] = []
+    @State private var errorMessage: String?
 
     var body: some View {
         NavigationStack {
@@ -91,6 +92,15 @@ struct ContentView: View {
             .task {
                 await loadBoxes()
             }
+            .alert("Error", isPresented: .constant(errorMessage != nil), actions: {
+                Button("OK", role: .cancel) {
+                    errorMessage = nil
+                }
+            }, message: {
+                if let msg = errorMessage {
+                    Text(msg)
+                }
+            })
         }
     }
 
@@ -101,7 +111,7 @@ struct ContentView: View {
         do {
             boxes = try await APIClient.shared.listBoxes()
         } catch {
-            print("Error loading boxes: \(error.localizedDescription)")
+            errorMessage = "Error loading boxes: \(error.localizedDescription)"
         }
     }
 
@@ -117,7 +127,7 @@ struct ContentView: View {
                 )
                 boxes.append(newBox)
             } catch {
-                print("Error creating box: \(error.localizedDescription)")
+                errorMessage = "Error creating box: \(error.localizedDescription)"
             }
         }
     }
@@ -131,7 +141,7 @@ struct ContentView: View {
         do {
             searchResults = try await APIClient.shared.searchItems(query: query)
         } catch {
-            print("Search error: \(error.localizedDescription)")
+            errorMessage = "Search error: \(error.localizedDescription)"
             searchResults = []
         }
     }
@@ -144,7 +154,7 @@ struct ContentView: View {
                     try await APIClient.shared.deleteBoxFromAPI(boxId: boxId)
                     boxes.remove(at: index)
                 } catch {
-                    print("Error deleting box: \(error)")
+                    errorMessage = "Error deleting box: \(error.localizedDescription)"
                 }
             }
         }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dmytro Golub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# HomeInventory
+
+A simple SwiftUI app for tracking boxes and items in your home. The project can run on iOS and macOS.
+
+## Building
+
+Open `HomeInventory.xcodeproj` in Xcode and build/run the **HomeInventory** scheme. The project uses async/await and requires Xcode 15 or newer.
+
+The backend API defaults to `http://127.0.0.1:8000`. To point the app at another server, set the `API_BASE_URL` environment variable in the run scheme.
+
+## Tests
+
+Unit and UI test targets are included but contain only template code. Future work could add real tests for `APIClient` and the UI.
+
+## License
+
+This project is released under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- add README with build notes
- ignore Xcode derived data
- add MIT license
- allow API base URL override via environment variable
- show error alerts in UI

## Testing
- `xcodebuild -list -project HomeInventory.xcodeproj` *(fails: command not found)*
- `swift test` *(fails: Package.swift not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b2e58e188331937cce102868f857