### PR TITLE
Show box photo on detail screen

### DIFF
--- a/HomeInventory/BoxDetailView.swift
+++ b/HomeInventory/BoxDetailView.swift
@@ -18,6 +18,19 @@ struct BoxDetailView: View {
     var body: some View {
         List {
             if let detail = viewModel.detail {
+                if let url = viewModel.boxPhotoURL {
+                    Section {
+                        AsyncImage(url: url) { image in
+                            image
+                                .resizable()
+                                .scaledToFit()
+                                .frame(maxHeight: 200)
+                                .cornerRadius(8)
+                        } placeholder: {
+                            ProgressView()
+                        }
+                    }
+                }
                 Section {
                     Text("Number: \(detail.number)")
                     if let description = detail.description {

--- a/HomeInventory/BoxDetailViewModel.swift
+++ b/HomeInventory/BoxDetailViewModel.swift
@@ -30,4 +30,11 @@ class BoxDetailViewModel: ObservableObject {
     func photoURL(for filename: String) -> URL {
         APIClient.shared.photoURL(for: filename)
     }
+
+    var boxPhotoURL: URL? {
+        if let filename = detail?.photoFilename {
+            return photoURL(for: filename)
+        }
+        return detail?.photoURL
+    }
 }

--- a/HomeInventory/Models.swift
+++ b/HomeInventory/Models.swift
@@ -11,10 +11,14 @@ struct Box: Identifiable, Codable {
     let id: Int
     let number: String
     let description: String?
+    let photoURL: URL?
+    let photoFilename: String?
     let createdAt: Date
 
     enum CodingKeys: String, CodingKey {
         case id, number, description
+        case photoURL = "photo_url"
+        case photoFilename = "photo_filename"
         case createdAt = "created_at"
     }
 }
@@ -42,11 +46,15 @@ struct BoxDetail: Codable {
     let id: Int
     let number: String
     let description: String?
+    let photoURL: URL?
+    let photoFilename: String?
     let createdAt: Date
     let items: [Item]?
 
     enum CodingKeys: String, CodingKey {
         case id, number, description, items
+        case photoURL = "photo_url"
+        case photoFilename = "photo_filename"
         case createdAt = "created_at"
     }
 }


### PR DESCRIPTION
## Summary
- decode box photo information from the API
- expose `boxPhotoURL` on `BoxDetailViewModel`
- display the box photo at the top of `BoxDetailView`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685826f8a31083318066ef7b0280e4de