### PR TITLE
Show thumbnail images for items

### DIFF
--- a/HomeInventory/BoxDetailView.swift
+++ b/HomeInventory/BoxDetailView.swift
@@ -40,21 +40,27 @@ struct BoxDetailView: View {
 
                 Section {
                     ForEach(detail.items ?? []) { item in
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text(item.name)
-                            if let note = item.note {
-                                Text(note)
-                                    .font(.caption)
-                            }
+                        HStack(alignment: .top, spacing: 8) {
                             if let filename = item.photoFilename {
                                 AsyncImage(url: viewModel.photoURL(for: filename)) { image in
                                     image
                                         .resizable()
-                                        .scaledToFit()
-                                        .frame(maxHeight: 200)
+                                        .scaledToFill()
+                                        .frame(width: 60, height: 60)
+                                        .clipped()
                                         .cornerRadius(8)
                                 } placeholder: {
                                     ProgressView()
+                                        .frame(width: 60, height: 60)
+                                }
+                            }
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.name)
+                                if let note = item.note {
+                                    Text(note)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- display each item's photo as a small thumbnail in BoxDetailView

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68582ca971b08331848e99e6ed6e4988