### PR TITLE
Add item detail screen

### DIFF
--- a/HomeInventory/BoxDetailView.swift
+++ b/HomeInventory/BoxDetailView.swift
@@ -40,31 +40,35 @@ struct BoxDetailView: View {
 
                 Section {
                     ForEach(detail.items ?? []) { item in
-                        HStack(alignment: .top, spacing: 8) {
-                            if let filename = item.photoFilename {
-                                AsyncImage(url: viewModel.photoURL(for: filename)) { image in
-                                    image
-                                        .resizable()
-                                        .scaledToFill()
-                                        .frame(width: 60, height: 60)
-                                        .clipped()
-                                        .cornerRadius(8)
-                                } placeholder: {
-                                    ProgressView()
-                                        .frame(width: 60, height: 60)
+                        NavigationLink {
+                            ItemDetailView(item: item, boxNumber: detail.number)
+                        } label: {
+                            HStack(alignment: .top, spacing: 8) {
+                                if let filename = item.photoFilename {
+                                    AsyncImage(url: viewModel.photoURL(for: filename)) { image in
+                                        image
+                                            .resizable()
+                                            .scaledToFill()
+                                            .frame(width: 60, height: 60)
+                                            .clipped()
+                                            .cornerRadius(8)
+                                    } placeholder: {
+                                        ProgressView()
+                                            .frame(width: 60, height: 60)
+                                    }
                                 }
-                            }
 
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(item.name)
-                                if let note = item.note {
-                                    Text(note)
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(item.name)
+                                    if let note = item.note {
+                                        Text(note)
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
                                 }
                             }
+                            .padding(.vertical, 4)
                         }
-                        .padding(.vertical, 4)
                     }
                 }
             } else if viewModel.isLoading {

--- a/HomeInventory/ContentView.swift
+++ b/HomeInventory/ContentView.swift
@@ -21,23 +21,27 @@ struct ContentView: View {
                 if !searchText.isEmpty {
                     Section("Search Results") {
                         ForEach(searchResults) { item in
-                            VStack(alignment: .leading) {
-                                Text(item.name)
-                                if let note = item.note {
-                                    Text(note)
-                                        .font(.caption)
-                                        .foregroundColor(.gray)
-                                }
+                            NavigationLink {
+                                ItemDetailView(item: item,
+                                               boxNumber: boxes.first(where: { $0.id == item.boxId })?.number)
+                            } label: {
+                                VStack(alignment: .leading) {
+                                    Text(item.name)
+                                    if let note = item.note {
+                                        Text(note)
+                                            .font(.caption)
+                                            .foregroundColor(.gray)
+                                    }
 
-
-                                if let box = boxes.first(where: { $0.id == item.boxId }) {
-                                    Text("Box: \(box.number)")
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                } else {
-                                    Text("Box: Unknown")
-                                        .font(.caption)
-                                        .foregroundColor(.red)
+                                    if let box = boxes.first(where: { $0.id == item.boxId }) {
+                                        Text("Box: \(box.number)")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    } else {
+                                        Text("Box: Unknown")
+                                            .font(.caption)
+                                            .foregroundColor(.red)
+                                    }
                                 }
                             }
                         }

--- a/HomeInventory/ItemDetailView.swift
+++ b/HomeInventory/ItemDetailView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct ItemDetailView: View {
+    let item: Item
+    let boxNumber: String?
+
+    private var photoURL: URL? {
+        if let filename = item.photoFilename {
+            return APIClient.shared.photoURL(for: filename)
+        }
+        return item.photoURL
+    }
+
+    var body: some View {
+        List {
+            if let url = photoURL {
+                Section {
+                    AsyncImage(url: url) { image in
+                        image
+                            .resizable()
+                            .scaledToFit()
+                            .frame(maxHeight: 200)
+                            .cornerRadius(8)
+                    } placeholder: {
+                        ProgressView()
+                    }
+                }
+            }
+
+            Section {
+                Text(item.name)
+                    .font(.headline)
+
+                if let note = item.note {
+                    Text(note)
+                }
+
+                if let boxNumber {
+                    Text("Box: \(boxNumber)")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .navigationTitle("Item Details")
+    }
+}
+
+#Preview {
+    let item = Item(id: 1, boxId: 1, name: "Sample", note: "Some note", photoURL: nil, photoFilename: nil, createdAt: .init())
+    return NavigationStack { ItemDetailView(item: item, boxNumber: "1") }
+}


### PR DESCRIPTION
## Summary
- show single item detail with image and text
- add links to ItemDetailView from box details and search results

## Testing
- `xcodebuild -list -project HomeInventory.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685834c6432c8331a91ef1f0a927d9fa