### PR TITLE
Add Vision-based item name suggestions

### DIFF
--- a/HomeInventory/AddItemView.swift
+++ b/HomeInventory/AddItemView.swift
@@ -23,6 +23,15 @@ struct AddItemView: View {
                     TextField("Note", text: $viewModel.note)
                 }
                 PhotoPickerSection(photo: $viewModel.photo)
+                if !viewModel.suggestedNames.isEmpty {
+                    Section("Suggestions") {
+                        ForEach(viewModel.suggestedNames, id: \.self) { suggestion in
+                            Button(action: { viewModel.name = suggestion }) {
+                                Text(suggestion)
+                            }
+                        }
+                    }
+                }
             }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/HomeInventory/ImageClassifier.swift
+++ b/HomeInventory/ImageClassifier.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Vision
+
+class ImageClassifier {
+    static let shared = ImageClassifier()
+
+    func classify(imageData: Data) async throws -> [String] {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    let request = VNClassifyImageRequest()
+                    let handler = VNImageRequestHandler(data: imageData, options: [:])
+                    try handler.perform([request])
+                    let results = (request.results as? [VNClassificationObservation])?.map { $0.identifier } ?? []
+                    continuation.resume(returning: results)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ImageClassifier` utility that uses `VNClassifyImageRequest`
- update `AddItemViewModel` to classify selected photos and expose suggested names
- show suggestion buttons in `AddItemView`

## Testing
- `xcodebuild -list -project HomeInventory.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584549e1988331939e9d4795f14e14