### PR TITLE
Add camera capture option when selecting photos

### DIFF
--- a/HomeInventory.xcodeproj/project.pbxproj
+++ b/HomeInventory.xcodeproj/project.pbxproj
@@ -403,6 +403,7 @@
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Capture photos of items and boxes.";
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -443,6 +444,7 @@
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Capture photos of items and boxes.";
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/HomeInventory/AddItemView.swift
+++ b/HomeInventory/AddItemView.swift
@@ -76,6 +76,7 @@ struct PhotoPickerSection: View {
 #if os(iOS)
             Button("Take Photo") {
                 if isCameraAvailable {
+                    capturedImage = nil
                     isShowingCamera = true
                 }
             }
@@ -145,6 +146,7 @@ struct ImagePicker: UIViewControllerRepresentable {
         }
 
         func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.image = nil
             picker.dismiss(animated: true)
         }
     }

--- a/HomeInventory/AddItemView.swift
+++ b/HomeInventory/AddItemView.swift
@@ -57,6 +57,10 @@ struct PhotoPickerSection: View {
 #if os(iOS)
     @State private var isShowingCamera = false
     @State private var capturedImage: UIImage?
+
+    private var isCameraAvailable: Bool {
+        UIImagePickerController.isSourceTypeAvailable(.camera)
+    }
 #endif
 
     var body: some View {
@@ -71,8 +75,11 @@ struct PhotoPickerSection: View {
                 }
 #if os(iOS)
             Button("Take Photo") {
-                isShowingCamera = true
+                if isCameraAvailable {
+                    isShowingCamera = true
+                }
             }
+            .disabled(!isCameraAvailable)
             .sheet(isPresented: $isShowingCamera) {
                 ImagePicker(image: $capturedImage)
                     .onDisappear {


### PR DESCRIPTION
### Motivation
- Enable taking a photo from the device camera when creating a box or item so users can attach a captured image at creation time.
- Reuse the existing shared photo picker UI so the camera flow integrates with both `AddBoxView` and `AddItemView` photo bindings.

### Description
- Updated `HomeInventory/AddItemView.swift` to import `UIKit` on iOS and add iOS-only state for camera presentation and captured image storage.
- Added a "Take Photo" button to `PhotoPickerSection` that presents a sheet wrapping a new `ImagePicker` view when running on iOS.
- Implemented `ImagePicker` as a `UIViewControllerRepresentable` that uses `UIImagePickerController` with a coordinator to capture the camera image and write JPEG data back into the existing `photo` binding.
- Preserved the existing `PhotosPicker` behavior so selecting from library and taking a new photo both populate the same `photo` data.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f54166f048331b648e8aaf8fb5c53)